### PR TITLE
Webpack v4 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class DelWebpackPlugin {
     }
 
     if (compiler.hooks) {
-      compiler.hooks.done.tapAsync('del-webpack-plugin', callback)
+      compiler.hooks.done.tap('del-webpack-plugin', callback)
     } else {
       compiler.plugin('done', callback)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class DelWebpackPlugin {
   apply (compiler) {
     const outputPath = compiler.options.output.path
 
-    compiler.plugin('done', stats => {
+    const callback = stats => {
       // check all modules work
       if (stats.hasErrors()) {
         console.log()
@@ -54,7 +54,13 @@ class DelWebpackPlugin {
           console.log()
         }
       })
-    })
+    }
+
+    if (compiler.hooks) {
+      compiler.hooks.done.tapAsync('del-webpack-plugin', callback)
+    } else {
+      compiler.plugin('done', callback)
+    }
   }
 }
 


### PR DESCRIPTION
In my limited testing as a new webpack user, this plugin already works fine with webpack v4 so all that's needed is to squash the deprecation warning. I expect this change to be fully backwards compatible with older webpack versions.

I'm making this change using the Github web interface so please excuse any silly mistakes or lack of testing!

Fixes #5